### PR TITLE
Use custom network config

### DIFF
--- a/templates/docker-compose.yaml.j2
+++ b/templates/docker-compose.yaml.j2
@@ -41,8 +41,6 @@ services:
       - fluentbit
     labels:
       - "container=hoprd"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
   nodeexporter:
     image: prom/node-exporter:v1.8.2
     container_name: nodeexporter

--- a/templates/docker-compose.yaml.j2
+++ b/templates/docker-compose.yaml.j2
@@ -3,6 +3,12 @@ networks:
   hoprnet:
     name: hoprnet
     driver: bridge
+    ipam:
+      driver: default
+      config: 
+        - subnet: 172.30.0.0/16
+          ip_range: 172.30.5.0/24
+          gateway: 172.30.0.1
 services:
   hoprd:
     image: europe-west3-docker.pkg.dev/hoprassociation/docker-images/hoprd:${HOPRD_VERSION}
@@ -35,6 +41,8 @@ services:
       - fluentbit
     labels:
       - "container=hoprd"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   nodeexporter:
     image: prom/node-exporter:v1.8.2
     container_name: nodeexporter


### PR DESCRIPTION
Use specific network config in Docker compose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker Compose network settings to specify custom IP allocation parameters.
  - Enabled containers to resolve the host machine's gateway address using a standardized hostname.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->